### PR TITLE
Bump FE to v3.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends:
 Imports:
   Andromeda,
 	DatabaseConnector (>= 6.3.1),
-	FeatureExtraction  (>= 3.5.0),
+	FeatureExtraction  (>= 3.5.1),
 	SqlRender (>= 1.9.0),
 	ParallelLogger (>= 3.0.0),
 	checkmate,


### PR DESCRIPTION
Force to use the patched version of FeatureExtraction

