### PR TITLE
Updates to support FeatureExtraction v3.6.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Characterization
 Type: Package
 Title: Characterizations of Cohorts
-Version: 0.2.0
+Version: 0.2.1
 Date: 2024-04-03
 Authors@R: c(
 	person("Jenna", "Reps", , "reps@ohdsi.org", role = c("aut", "cre")),
@@ -17,7 +17,7 @@ Depends:
 Imports:
   Andromeda,
 	DatabaseConnector (>= 6.3.1),
-	FeatureExtraction  (>= 3.5.0),
+	FeatureExtraction  (>= 3.6.0),
 	SqlRender (>= 1.9.0),
 	ParallelLogger (>= 3.0.0),
 	checkmate,

--- a/R/AggregateCovariates.R
+++ b/R/AggregateCovariates.R
@@ -165,7 +165,7 @@ computeAggregateCovariateAnalyses <- function(
     cdmDatabaseSchema = cdmDatabaseSchema,
     cohortTable = "#agg_cohorts",
     cohortTableIsTemp = T,
-    cohortId = -1,
+    cohortIds = c(-1),
     covariateSettings = aggregateCovariateSettings$covariateSettings,
     cdmVersion = cdmVersion,
     aggregated = T,

--- a/inst/settings/resultsDataModelSpecification.csv
+++ b/inst/settings/resultsDataModelSpecification.csv
@@ -59,6 +59,8 @@ covariate_ref,covariate_id,bigint,Y,Y,N,N,The covariate identifier
 covariate_ref,covariate_name,varchar,Y,N,N,N,The covariate name
 covariate_ref,analysis_id,int,Y,N,N,N,The analysis identifier
 covariate_ref,concept_id,bigint,Y,N,N,N,The concept identifier
+covariate_ref,value_as_concept_id,int,N,N,N,N,The value as concept_id for features created from observation or measurement values
+covariate_ref,collisions,int,N,N,N,N,The number of collisions found for the covariate_id
 covariates,database_id,varchar(100),Y,Y,N,N,The database identifier
 covariates,run_id,int,Y,Y,N,N,The run identifier
 covariates,cohort_definition_id,int,Y,Y,N,N,The cohort definition id

--- a/inst/sql/sql_server/ResultTables.sql
+++ b/inst/sql/sql_server/ResultTables.sql
@@ -93,7 +93,9 @@ CREATE TABLE @my_schema.@table_prefixcovariate_ref (
     covariate_id int NOT NULL,
     covariate_name varchar(max) NOT NULL,
     analysis_id int NOT NULL,
-    concept_id int
+    concept_id int,
+    value_as_concept_id int,
+    collisions int
 );
 
 CREATE TABLE @my_schema.@table_prefixcovariates (


### PR DESCRIPTION
Aims to address #53. This PR does not include an RMM migration so thinking that we might want to create a migration for this change if you agree @jreps?

