### PR TITLE
#fake table error

### DIFF
--- a/R/RunCharacterization.R
+++ b/R/RunCharacterization.R
@@ -421,7 +421,7 @@ runCharacterizationsInParallel <- function(x) {
       )
     },
     error = function(e) {
-      rlang::inform(e)
+      rlang::inform(e$message)
       return(FALSE)
     }
   )

--- a/R/RunCharacterization.R
+++ b/R/RunCharacterization.R
@@ -421,7 +421,7 @@ runCharacterizationsInParallel <- function(x) {
       )
     },
     error = function(e) {
-      print(e)
+      rlang::inform(e)
       return(FALSE)
     }
   )

--- a/inst/sql/sql_server/ConceptCountsDuring.sql
+++ b/inst/sql/sql_server/ConceptCountsDuring.sql
@@ -1,7 +1,7 @@
 -- adding line below to prevent warnings
 IF OBJECT_ID('tempdb..#fake', 'U') IS NOT NULL
 	DROP TABLE #fake;
-SELECT '@row_id_field' as cname into #fake WHERE 1 = 1;
+SELECT '@row_id_field' as cname into #fake FROM @cdm_database_schema.@domain_table WHERE 1 = 0;
 
 -- Feature construction
 {@aggregated} ? {

--- a/inst/sql/sql_server/ConceptCountsDuring.sql
+++ b/inst/sql/sql_server/ConceptCountsDuring.sql
@@ -1,7 +1,7 @@
 -- adding line below to prevent warnings
 IF OBJECT_ID('tempdb..#fake', 'U') IS NOT NULL
 	DROP TABLE #fake;
-SELECT '@row_id_field' as cname into #fake;
+SELECT '@row_id_field' as cname into #fake WHERE 1 = 1;
 
 -- Feature construction
 {@aggregated} ? {

--- a/inst/sql/sql_server/ConceptCountsDuring.sql
+++ b/inst/sql/sql_server/ConceptCountsDuring.sql
@@ -1,7 +1,7 @@
 -- adding line below to prevent warnings
 IF OBJECT_ID('tempdb..#fake', 'U') IS NOT NULL
 	DROP TABLE #fake;
-SELECT "@row_id_field" as cname into #fake;
+SELECT '@row_id_field' as cname into #fake;
 
 -- Feature construction
 {@aggregated} ? {

--- a/inst/sql/sql_server/DomainConceptDuring.sql
+++ b/inst/sql/sql_server/DomainConceptDuring.sql
@@ -1,7 +1,7 @@
 -- adding lines below to prevent warning
 IF OBJECT_ID('tempdb..#fake', 'U') IS NOT NULL
 	DROP TABLE #fake;
-SELECT '@domain_end_date' as cname into #fake WHERE 1=1;
+SELECT '@domain_end_date' as cname into #fake FROM @cdm_database_schema.@domain_table WHERE 1 = 0;
 
 -- Feature construction
 SELECT

--- a/inst/sql/sql_server/DomainConceptDuring.sql
+++ b/inst/sql/sql_server/DomainConceptDuring.sql
@@ -1,7 +1,7 @@
 -- adding lines below to prevent warning
 IF OBJECT_ID('tempdb..#fake', 'U') IS NOT NULL
 	DROP TABLE #fake;
-SELECT '@domain_end_date' as cname into #fake;
+SELECT '@domain_end_date' as cname into #fake WHERE 1=1;
 
 -- Feature construction
 SELECT

--- a/inst/sql/sql_server/DomainConceptDuring.sql
+++ b/inst/sql/sql_server/DomainConceptDuring.sql
@@ -1,7 +1,7 @@
 -- adding lines below to prevent warning
 IF OBJECT_ID('tempdb..#fake', 'U') IS NOT NULL
 	DROP TABLE #fake;
-SELECT "@domain_end_date" as cname into #fake;
+SELECT '@domain_end_date' as cname into #fake;
 
 -- Feature construction
 SELECT

--- a/inst/sql/sql_server/DomainConceptGroupDuring.sql
+++ b/inst/sql/sql_server/DomainConceptGroupDuring.sql
@@ -1,7 +1,7 @@
 -- add dummy code with all imputs to stop annoying warnings
 IF OBJECT_ID('tempdb..#fake', 'U') IS NOT NULL
 	DROP TABLE #fake;
-SELECT "@domain_end_date" as cname into #fake;
+SELECT '@domain_end_date' as cname into #fake;
 
 IF OBJECT_ID('tempdb..#groups', 'U') IS NOT NULL
 	DROP TABLE #groups;

--- a/inst/sql/sql_server/DomainConceptGroupDuring.sql
+++ b/inst/sql/sql_server/DomainConceptGroupDuring.sql
@@ -1,7 +1,7 @@
 -- add dummy code with all imputs to stop annoying warnings
 IF OBJECT_ID('tempdb..#fake', 'U') IS NOT NULL
 	DROP TABLE #fake;
-SELECT '@domain_end_date' as cname into #fake WHERE 1 = 1;
+SELECT '@domain_end_date' as cname into #fake FROM @cdm_database_schema.@domain_table WHERE 1 = 0;
 
 IF OBJECT_ID('tempdb..#groups', 'U') IS NOT NULL
 	DROP TABLE #groups;

--- a/inst/sql/sql_server/DomainConceptGroupDuring.sql
+++ b/inst/sql/sql_server/DomainConceptGroupDuring.sql
@@ -1,7 +1,7 @@
 -- add dummy code with all imputs to stop annoying warnings
 IF OBJECT_ID('tempdb..#fake', 'U') IS NOT NULL
 	DROP TABLE #fake;
-SELECT '@domain_end_date' as cname into #fake;
+SELECT '@domain_end_date' as cname into #fake WHERE 1 = 1;
 
 IF OBJECT_ID('tempdb..#groups', 'U') IS NOT NULL
 	DROP TABLE #groups;


### PR DESCRIPTION
Aims to fix #79  by using single quotes for constants in SQL and to use `rlang::inform` to print errors with the hope that this will surface problems in the log files.

